### PR TITLE
fix: properly output painted image while preserving mask functionality

### DIFF
--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -1155,7 +1155,6 @@ class MaskEditorDialog extends ComfyDialog {
       }
     }
 
-
     if (success && paintsuccess) {
       ComfyApp.onClipspaceEditorSave()
       this.close()
@@ -1221,8 +1220,8 @@ class MaskEditorDialog extends ComfyDialog {
         )
         ComfyApp.clipspace.imgs[paintedIndex] = newImage
 
-        console.log("UPLOADIMAGE: ", ComfyApp.clipspace)
-        console.log("UPLOADIMAGE: ", ComfyApp.clipspace.imgs[paintedIndex])
+        console.log('UPLOADIMAGE: ', ComfyApp.clipspace)
+        console.log('UPLOADIMAGE: ', ComfyApp.clipspace.imgs[paintedIndex])
 
         // Update images array if it exists
         if (ComfyApp.clipspace.images) {
@@ -1325,15 +1324,30 @@ class CanvasHistory {
 
   async saveInitialState() {
     await this.pullCanvas()
-    if (!this.canvas.width || !this.canvas.height || !this.rgbCanvas.width || !this.rgbCanvas.height) {
+    if (
+      !this.canvas.width ||
+      !this.canvas.height ||
+      !this.rgbCanvas.width ||
+      !this.rgbCanvas.height
+    ) {
       // Canvas not ready yet, defer initialization
       requestAnimationFrame(() => this.saveInitialState())
       return
     }
 
     this.clearStates()
-    const maskState = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height)
-    const rgbState = this.rgbCtx.getImageData(0, 0, this.rgbCanvas.width, this.rgbCanvas.height)
+    const maskState = this.ctx.getImageData(
+      0,
+      0,
+      this.canvas.width,
+      this.canvas.height
+    )
+    const rgbState = this.rgbCtx.getImageData(
+      0,
+      0,
+      this.rgbCanvas.width,
+      this.rgbCanvas.height
+    )
     this.states.push({ mask: maskState, rgb: rgbState })
     this.currentStateIndex = 0
     this.initialized = true
@@ -1347,8 +1361,18 @@ class CanvasHistory {
     }
 
     this.states = this.states.slice(0, this.currentStateIndex + 1)
-    const maskState = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height)
-    const rgbState = this.rgbCtx.getImageData(0, 0, this.rgbCanvas.width, this.rgbCanvas.height)
+    const maskState = this.ctx.getImageData(
+      0,
+      0,
+      this.canvas.width,
+      this.canvas.height
+    )
+    const rgbState = this.rgbCtx.getImageData(
+      0,
+      0,
+      this.rgbCanvas.width,
+      this.rgbCanvas.height
+    )
     this.states.push({ mask: maskState, rgb: rgbState })
     this.currentStateIndex++
 
@@ -1368,7 +1392,10 @@ class CanvasHistory {
   }
 
   redo() {
-    if (this.states.length > 1 && this.currentStateIndex < this.states.length - 1) {
+    if (
+      this.states.length > 1 &&
+      this.currentStateIndex < this.states.length - 1
+    ) {
       this.currentStateIndex++
       this.restoreState(this.states[this.currentStateIndex])
     } else {
@@ -2106,8 +2133,9 @@ class BrushTool {
     this.messageBroker.subscribe('setBrushShape', (type: BrushShape) =>
       this.setBrushType(type)
     )
-    this.messageBroker.subscribe('setActiveLayer', (layer: 'mask' | 'rgb') =>
-      this.activeLayer = layer
+    this.messageBroker.subscribe(
+      'setActiveLayer',
+      (layer: 'mask' | 'rgb') => (this.activeLayer = layer)
     )
     this.messageBroker.subscribe(
       'setBrushSmoothingPrecision',
@@ -2182,33 +2210,33 @@ class BrushTool {
   }
 
   private async startDrawing(event: PointerEvent) {
-    this.isDrawing = true;
-    let compositionOp: CompositionOperation;
-    let currentTool = await this.messageBroker.pull('currentTool');
-    let coords = { x: event.offsetX, y: event.offsetY };
-    let coords_canvas = await this.messageBroker.pull('screenToCanvas', coords);
-    await this.createBrushStrokeCanvas();
+    this.isDrawing = true
+    let compositionOp: CompositionOperation
+    let currentTool = await this.messageBroker.pull('currentTool')
+    let coords = { x: event.offsetX, y: event.offsetY }
+    let coords_canvas = await this.messageBroker.pull('screenToCanvas', coords)
+    await this.createBrushStrokeCanvas()
 
     //set drawing mode
     if (currentTool === Tools.Eraser || event.buttons == 2) {
-        compositionOp = CompositionOperation.DestinationOut; //eraser
+      compositionOp = CompositionOperation.DestinationOut //eraser
     } else {
-        compositionOp = CompositionOperation.SourceOver; //pen
+      compositionOp = CompositionOperation.SourceOver //pen
     }
 
     // Only check for line drawing if using the Pen tool
     if (currentTool === Tools.Pen && event.shiftKey && this.lineStartPoint) {
-        this.isDrawingLine = true;
-        this.drawLine(this.lineStartPoint, coords_canvas, compositionOp);
+      this.isDrawingLine = true
+      this.drawLine(this.lineStartPoint, coords_canvas, compositionOp)
     } else {
-        this.isDrawingLine = false;
-        this.init_shape(compositionOp);
-        this.draw_shape(coords_canvas);
+      this.isDrawingLine = false
+      this.init_shape(compositionOp)
+      this.draw_shape(coords_canvas)
     }
-    this.lineStartPoint = coords_canvas;
-    this.smoothingCordsArray = [coords_canvas]; //used to smooth the drawing line
-    this.smoothingLastDrawTime = new Date();
-}
+    this.lineStartPoint = coords_canvas
+    this.smoothingCordsArray = [coords_canvas] //used to smooth the drawing line
+    this.smoothingLastDrawTime = new Date()
+  }
 
   private async handleDrawing(event: PointerEvent) {
     var diff = performance.now() - this.smoothingLastDrawTime.getTime()
@@ -2238,16 +2266,19 @@ class BrushTool {
   }
 
   private async drawEnd(event: PointerEvent) {
-    const coords = { x: event.offsetX, y: event.offsetY };
-    const coords_canvas = await this.messageBroker.pull('screenToCanvas', coords);
+    const coords = { x: event.offsetX, y: event.offsetY }
+    const coords_canvas = await this.messageBroker.pull(
+      'screenToCanvas',
+      coords
+    )
 
     if (this.isDrawing) {
-        this.isDrawing = false;
-        this.messageBroker.publish('saveState');
-        this.lineStartPoint = coords_canvas;
-        this.initialDraw = true;
+      this.isDrawing = false
+      this.messageBroker.publish('saveState')
+      this.lineStartPoint = coords_canvas
+      this.initialDraw = true
     }
-}
+  }
 
   private drawWithBetterSmoothing(point: Point) {
     // Add current point to the smoothing array
@@ -2419,49 +2450,65 @@ class BrushTool {
   //helper functions
 
   private async draw_shape(point: Point, overrideOpacity?: number) {
-    const brushSettings: Brush = this.brushSettings;
-    const currentTool = await this.messageBroker.pull('currentTool');
-    const size = brushSettings.size;
-    const sliderOpacity = brushSettings.opacity;
-    const opacity = overrideOpacity == undefined ? sliderOpacity : overrideOpacity;
-    const hardness = brushSettings.hardness;
+    const brushSettings: Brush = this.brushSettings
+    const currentTool = await this.messageBroker.pull('currentTool')
+    const size = brushSettings.size
+    const sliderOpacity = brushSettings.opacity
+    const opacity =
+      overrideOpacity == undefined ? sliderOpacity : overrideOpacity
+    const hardness = brushSettings.hardness
 
-    const x = point.x;
-    const y = point.y;
+    const x = point.x
+    const y = point.y
 
     // Extend the gradient radius beyond the brush size
-    const extendedSize = size * (2 - hardness);
+    const extendedSize = size * (2 - hardness)
 
-    let gradient: CanvasGradient;
-    let maskCtx: CanvasRenderingContext2D;
-    let rgbCtx: CanvasRenderingContext2D;
-    rgbCtx = await this.messageBroker.pull('rgbCtx');
-    maskCtx = await this.messageBroker.pull('maskCtx');
-    const maskColor = await this.messageBroker.pull('getMaskColor');
+    let gradient: CanvasGradient
+    let maskCtx: CanvasRenderingContext2D
+    let rgbCtx: CanvasRenderingContext2D
+    rgbCtx = await this.messageBroker.pull('rgbCtx')
+    maskCtx = await this.messageBroker.pull('maskCtx')
+    const maskColor = await this.messageBroker.pull('getMaskColor')
 
-    if (this.activeLayer === 'rgb' && (currentTool === Tools.Eraser || currentTool === Tools.RGBPaint)) {
-        // Handle RGB painting
-        gradient = rgbCtx.createRadialGradient(x, y, 0, x, y, extendedSize);
-        const rgbaColor = this.hexToRgba(this.rgbColor, opacity);
-        gradient.addColorStop(0, rgbaColor);
-        gradient.addColorStop(hardness, rgbaColor);
-        gradient.addColorStop(1, this.hexToRgba(this.rgbColor, 0));
-        rgbCtx.fillStyle = gradient;
-        rgbCtx.beginPath();
-        rgbCtx.arc(x, y, extendedSize, 0, Math.PI * 2, false);
-        rgbCtx.fill();
-    } else if (this.activeLayer === 'mask' && (currentTool === Tools.Eraser || currentTool === Tools.Pen)) {
-        // Handle mask drawing/erasing
-        gradient = maskCtx.createRadialGradient(x, y, 0, x, y, extendedSize);
-        gradient.addColorStop(0, `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`);
-        gradient.addColorStop(hardness, `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`);
-        gradient.addColorStop(1, `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, 0)`);
-        maskCtx.fillStyle = gradient;
-        maskCtx.beginPath();
-        maskCtx.arc(x, y, extendedSize, 0, Math.PI * 2, false);
-        maskCtx.fill();
+    if (
+      this.activeLayer === 'rgb' &&
+      (currentTool === Tools.Eraser || currentTool === Tools.RGBPaint)
+    ) {
+      // Handle RGB painting
+      gradient = rgbCtx.createRadialGradient(x, y, 0, x, y, extendedSize)
+      const rgbaColor = this.hexToRgba(this.rgbColor, opacity)
+      gradient.addColorStop(0, rgbaColor)
+      gradient.addColorStop(hardness, rgbaColor)
+      gradient.addColorStop(1, this.hexToRgba(this.rgbColor, 0))
+      rgbCtx.fillStyle = gradient
+      rgbCtx.beginPath()
+      rgbCtx.arc(x, y, extendedSize, 0, Math.PI * 2, false)
+      rgbCtx.fill()
+    } else if (
+      this.activeLayer === 'mask' &&
+      (currentTool === Tools.Eraser || currentTool === Tools.Pen)
+    ) {
+      // Handle mask drawing/erasing
+      gradient = maskCtx.createRadialGradient(x, y, 0, x, y, extendedSize)
+      gradient.addColorStop(
+        0,
+        `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`
+      )
+      gradient.addColorStop(
+        hardness,
+        `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`
+      )
+      gradient.addColorStop(
+        1,
+        `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, 0)`
+      )
+      maskCtx.fillStyle = gradient
+      maskCtx.beginPath()
+      maskCtx.arc(x, y, extendedSize, 0, Math.PI * 2, false)
+      maskCtx.fill()
     }
-}
+  }
 
   private hexToRgba(hex: string, alpha: number): string {
     // Remove # if present
@@ -3241,52 +3288,52 @@ class UIManager {
   }
 
   private async createImageLayerSettings() {
-    const accentColor = this.darkMode ? 'maskEditor_accent_bg_dark' : 'maskEditor_accent_bg_light';
+    const accentColor = this.darkMode
+      ? 'maskEditor_accent_bg_dark'
+      : 'maskEditor_accent_bg_light'
 
-    const image_layer_settings_container = this.createContainer(true);
+    const image_layer_settings_container = this.createContainer(true)
 
-    const image_layer_settings_title = this.createHeadline('Layers');
+    const image_layer_settings_title = this.createHeadline('Layers')
 
-    var activeLayer: 'mask' | 'rgb' = 'mask';
+    var activeLayer: 'mask' | 'rgb' = 'mask'
 
     // Add a new container for layer selection
-    const layer_selection_container = this.createContainer(false);
-    layer_selection_container.classList.add(accentColor);
-    layer_selection_container.classList.add('maskEditor_layerRow');
+    const layer_selection_container = this.createContainer(false)
+    layer_selection_container.classList.add(accentColor)
+    layer_selection_container.classList.add('maskEditor_layerRow')
 
-    const mask_layer_button = document.createElement('button');
-    mask_layer_button.innerText = 'Activate Mask Layer';
+    const mask_layer_button = document.createElement('button')
+    mask_layer_button.innerText = 'Activate Mask Layer'
     mask_layer_button.addEventListener('click', () => {
-        this.messageBroker.publish('setActiveLayer', 'mask');
-        activeLayer = 'mask';
-        updateButtons();
-    });
-    
-    const rgb_layer_button = document.createElement('button');
-    rgb_layer_button.innerText = 'Activate Paint Layer';
-    rgb_layer_button.addEventListener('click', () => {
-        this.messageBroker.publish('setActiveLayer', 'rgb');
-        activeLayer = 'rgb';
-        updateButtons();
+      this.messageBroker.publish('setActiveLayer', 'mask')
+      activeLayer = 'mask'
+      updateButtons()
+    })
 
-        
-    });
-    
+    const rgb_layer_button = document.createElement('button')
+    rgb_layer_button.innerText = 'Activate Paint Layer'
+    rgb_layer_button.addEventListener('click', () => {
+      this.messageBroker.publish('setActiveLayer', 'rgb')
+      activeLayer = 'rgb'
+      updateButtons()
+    })
+
     function updateButtons() {
-        if (activeLayer === 'mask') {
-            mask_layer_button.style.display = 'none';
-            rgb_layer_button.style.display = 'block';
-        } else {
-            mask_layer_button.style.display = 'block';
-            rgb_layer_button.style.display = 'none';
-        }
+      if (activeLayer === 'mask') {
+        mask_layer_button.style.display = 'none'
+        rgb_layer_button.style.display = 'block'
+      } else {
+        mask_layer_button.style.display = 'block'
+        rgb_layer_button.style.display = 'none'
+      }
     }
 
     //layer_selection_container.appendChild(mask_layer_button);
     //layer_selection_container.appendChild(rgb_layer_button);
 
-   // image_layer_settings_container.appendChild(image_layer_settings_title);
-   // image_layer_settings_container.appendChild(layer_selection_container);
+    // image_layer_settings_container.appendChild(image_layer_settings_title);
+    // image_layer_settings_container.appendChild(layer_selection_container);
 
     const mask_layer_title = this.createContainerTitle('Mask Layer')
 
@@ -4042,7 +4089,8 @@ class UIManager {
     maskCtx.clearRect(0, 0, this.maskCanvas.width, this.maskCanvas.height)
 
     const alpha_url = new URL(
-      ComfyApp.clipspace?.imgs?.[ComfyApp.clipspace?.selectedIndex ?? 0]?.src ?? ''
+      ComfyApp.clipspace?.imgs?.[ComfyApp.clipspace?.selectedIndex ?? 0]?.src ??
+        ''
     )
     alpha_url.searchParams.delete('channel')
     alpha_url.searchParams.delete('preview')
@@ -4050,8 +4098,12 @@ class UIManager {
     let mask_image: HTMLImageElement = await this.loadImage(alpha_url)
 
     // original image load
-    if (!ComfyApp.clipspace?.imgs?.[ComfyApp.clipspace?.selectedIndex ?? 0]?.src) {
-      throw new Error('Unable to access image source - clipspace or image is null')
+    if (
+      !ComfyApp.clipspace?.imgs?.[ComfyApp.clipspace?.selectedIndex ?? 0]?.src
+    ) {
+      throw new Error(
+        'Unable to access image source - clipspace or image is null'
+      )
     }
 
     const rgb_url = new URL(
@@ -4074,31 +4126,35 @@ class UIManager {
     if (ComfyApp.clipspace.imgs[paintedIndex]) {
       const paintURL = new URL(ComfyApp.clipspace.imgs[paintedIndex].src)
       this.paint_URL = paintURL
-      this.paint_image = new Image ()
-      this.paint_image = await new Promise<HTMLImageElement>((resolve, reject) => {
-        const img = new Image()
-        img.onload = () => resolve(img)
-        img.onerror = reject
-        img.src = paintURL.toString()
-      })
-    } else if (ComfyApp.clipspace.images) {
-      if (ComfyApp.clipspace.images[paintedIndex]) {
-        const paintURL = new URL(ComfyApp.clipspace.images[paintedIndex].src)
-        this.paint_URL = paintURL
-        this.paint_image = new Image ()
-        this.paint_image = await new Promise<HTMLImageElement>((resolve, reject) => {
+      this.paint_image = new Image()
+      this.paint_image = await new Promise<HTMLImageElement>(
+        (resolve, reject) => {
           const img = new Image()
           img.onload = () => resolve(img)
           img.onerror = reject
           img.src = paintURL.toString()
-        })
+        }
+      )
+    } else if (ComfyApp.clipspace.images) {
+      if (ComfyApp.clipspace.images[paintedIndex]) {
+        const paintURL = new URL(ComfyApp.clipspace.images[paintedIndex].src)
+        this.paint_URL = paintURL
+        this.paint_image = new Image()
+        this.paint_image = await new Promise<HTMLImageElement>(
+          (resolve, reject) => {
+            const img = new Image()
+            img.onload = () => resolve(img)
+            img.onerror = reject
+            img.src = paintURL.toString()
+          }
+        )
       }
     }
 
     console.log(ComfyApp.clipspace)
-    console.log("IMG: ", this.image)
-    console.log("MASK: ", mask_image)
-    console.log("Paint: ", this.paint_image)
+    console.log('IMG: ', this.image)
+    console.log('MASK: ', mask_image)
+    console.log('Paint: ', this.paint_image)
 
     maskCanvas.width = this.image.width
     maskCanvas.height = this.image.height
@@ -4138,7 +4194,13 @@ class UIManager {
     imgCtx!.drawImage(orig_image, 0, 0, orig_image.width, orig_image.height)
     if (paint_image) {
       // rgbCtx.globalCompositeOperation = 'source-over'
-      rgbCtx!.drawImage(paint_image, 0, 0, paint_image.width, paint_image.height)
+      rgbCtx!.drawImage(
+        paint_image,
+        0,
+        0,
+        paint_image.width,
+        paint_image.height
+      )
     }
     await this.prepare_mask(
       mask_image,
@@ -4445,13 +4507,13 @@ class ToolManager {
     return this.currentTool
   }
 
-  private activeLayer: 'mask' | 'rgb' = 'mask';
+  private activeLayer: 'mask' | 'rgb' = 'mask'
 
   private async handleLayerSelection(layer: 'mask' | 'rgb') {
-      this.activeLayer = layer;
-      this.messageBroker.publish('setActiveLayer', layer);
-      this.messageBroker.publish('updateCursor');
-}
+    this.activeLayer = layer
+    this.messageBroker.publish('setActiveLayer', layer)
+    this.messageBroker.publish('updateCursor')
+  }
 
   private async handlePointerDown(event: PointerEvent) {
     event.preventDefault()
@@ -4514,7 +4576,9 @@ class ToolManager {
       return
     }
 
-    var isDrawingTool = [Tools.Pen, Tools.Eraser, Tools.RGBPaint].includes(this.currentTool)
+    var isDrawingTool = [Tools.Pen, Tools.Eraser, Tools.RGBPaint].includes(
+      this.currentTool
+    )
     //drawing
     if ([0, 2].includes(event.button) && isDrawingTool) {
       this.messageBroker.publish('drawStart', event)


### PR DESCRIPTION
Main repo PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/2921

This PR refactors maskeditor.ts's `save()` method for clarity and maintainability and fixes the bug where you couldn't output the painted image while preserving mask functionality.

To view the changes more easily, consult [e7cfae0](https://github.com/brucew4yn3rp/ComfyUI_frontend_ImageEditor/pull/1/commits/e7cfae0ec5869201dfd799edcc2dd2816aa7c3e1), as the PR's full changelist also contains prettier formatting that was necessary to pass the pre-commit hook.

The main culprit for the difficulty you were having was that [it is impossible to use a CanvasRenderingContext2D to create an image that has transparent pixels while preserving the transparent pixels' RGB values](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData#data_loss_due_to_browser_optimization). Instead, we use the `/upload/mask` endpoint and let the backend do the compositing. A possible alternative to doing so would be to use a WebGLRenderingContext instead, but that is extremely complicated, and I'm guessing that the API endpoint exists for this purpose.

## screenshot

![1751386554](https://github.com/user-attachments/assets/36a6b154-8537-45a6-8415-6c5e2c273a0a)
