### PR TITLE
fix: show correct preview after painting an image in MaskEditor; improve layer-selecting UX; fix rectangular brushes; add kb shortcuts to change brush size

### DIFF
--- a/src/composables/widgets/useImagePreviewWidget.ts
+++ b/src/composables/widgets/useImagePreviewWidget.ts
@@ -35,7 +35,9 @@ const renderPreview = (
     node.pointerDown = null
   }
 
-  const imgs = node.imgs ?? []
+  const imgs = (node.imgs ?? []).filter(
+    (img) => img.getAttribute('data-nopreview') !== 'true'
+  )
   let { imageIndex } = node
   const numImages = imgs.length
   if (numImages === 1 && !imageIndex) {

--- a/src/constants/coreKeybindings.ts
+++ b/src/constants/coreKeybindings.ts
@@ -181,5 +181,7 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
       shift: true
     },
     commandId: 'Comfy.Graph.ConvertToSubgraph'
-  }
+  },
+  { combo: { key: ']' }, commandId: 'Comfy.MaskEditor.BrushSize.Increase' },
+  { combo: { key: '[' }, commandId: 'Comfy.MaskEditor.BrushSize.Decrease' }
 ]

--- a/src/extensions/core/maskeditor.ts
+++ b/src/extensions/core/maskeditor.ts
@@ -3531,7 +3531,6 @@ class UIManager {
   ) {
     var slider_container = this.createContainer(true)
     var slider_title = this.createContainerTitle(title)
-
     var slider = document.createElement('input')
     slider.classList.add('maskEditor_sidePanelBrushRange')
     slider.setAttribute('type', 'range')
@@ -5346,6 +5345,18 @@ app.registerExtension({
         ComfyApp.clipspace_return_node = selectedNode
         openMaskEditor()
       }
+    },
+    {
+      id: 'Comfy.MaskEditor.BrushSize.Increase',
+      icon: 'pi pi-plus-circle',
+      label: 'Increase Brush Size in MaskEditor',
+      function: () => changeBrushSize((old) => _.clamp(old + 8, 1, 100))
+    },
+    {
+      id: 'Comfy.MaskEditor.BrushSize.Decrease',
+      icon: 'pi pi-minus-circle',
+      label: 'Decrease Brush Size in MaskEditor',
+      function: () => changeBrushSize((old) => _.clamp(old - 8, 1, 100))
     }
   ],
   init() {
@@ -5359,6 +5370,17 @@ app.registerExtension({
     )
   }
 })
+
+const changeBrushSize = async (sizeChanger: (oldSize: number) => number) => {
+  if (!isOpened()) return
+  const maskEditor = MaskEditorDialog.getInstance()
+  if (!maskEditor) return
+  const messageBroker = maskEditor.getMessageBroker()
+  const oldBrushSize = (await messageBroker.pull('brushSettings')).size
+  const newBrushSize = sizeChanger(oldBrushSize)
+  messageBroker.publish('setBrushSize', newBrushSize)
+  messageBroker.publish('updateBrushPreview')
+}
 
 // NOTE: This originally was re-implemented at each individual call site, which is obviously a poorly-maintainable approach. I moved it to be implemented here once, but this should likely be either be implemented as a project-wide utility, or better yet, we should use a networking library that already has retry logic built-in, such as TanStack Query or axios-retry.
 // - @duckcomfy

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -10,6 +10,7 @@ import type { IBaseWidget } from '@comfyorg/litegraph/dist/types/widgets'
 import _ from 'lodash'
 import type { ToastMessageOptions } from 'primevue/toast'
 import { reactive } from 'vue'
+
 import { useCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
 import { useWorkflowValidation } from '@/composables/useWorkflowValidation'
 import { st, t } from '@/i18n'
@@ -359,7 +360,7 @@ export class ComfyApp {
     if (selectedIndex != 0) {
       combinedIndex = selectedIndex + 2
     }
-    
+
     ComfyApp.clipspace = {
       widgets: widgets,
       imgs: imgs,
@@ -381,59 +382,69 @@ export class ComfyApp {
   static pasteFromClipspace(node: LGraphNode) {
     if (ComfyApp.clipspace) {
       // image paste
+      const combinedImgSrc =
+        ComfyApp.clipspace.imgs?.[ComfyApp.clipspace.combinedIndex].src
       if (ComfyApp.clipspace.imgs && node.imgs) {
         if (node.images && ComfyApp.clipspace.images) {
           if (ComfyApp.clipspace['img_paste_mode'] == 'selected') {
             node.images = [
               ComfyApp.clipspace.images[ComfyApp.clipspace['selectedIndex']]
-            ];
+            ]
           } else {
-            node.images = ComfyApp.clipspace.images;
+            node.images = ComfyApp.clipspace.images
           }
-  
-          if (app.nodeOutputs[node.id + ''])
-            app.nodeOutputs[node.id + ''].images = node.images;
+
+          if (app.nodeOutputs[node.id + '']) {
+            app.nodeOutputs[node.id + ''].images = node.images
+          }
         }
-  
+
         if (ComfyApp.clipspace.imgs) {
           // deep-copy to cut link with clipspace
           if (ComfyApp.clipspace['img_paste_mode'] == 'selected') {
-            const img = new Image();
+            const img = new Image()
             img.src =
-              ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src;
-            node.imgs = [img];
-            node.imageIndex = 0;
+              ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src
+            node.imgs = [img]
+            node.imageIndex = 0
           } else {
-            const imgs = [];
+            const imgs = []
             for (let i = 0; i < ComfyApp.clipspace.imgs.length; i++) {
-              imgs[i] = new Image();
-              imgs[i].src = ComfyApp.clipspace.imgs[i].src;
-              node.imgs = imgs;
+              imgs[i] = new Image()
+              imgs[i].src = ComfyApp.clipspace.imgs[i].src
+              node.imgs = imgs
             }
           }
         }
       }
-      
+
       // Paste the combined canvas if it exists
-      if (ComfyApp.clipspace.imgs?.[ComfyApp.clipspace.combinedIndex] && node.imgs) {
-        const combinedImg = new Image();
-        combinedImg.src = ComfyApp.clipspace.imgs[ComfyApp.clipspace.combinedIndex].src;
-        node.imgs.push(combinedImg); // Add the combined canvas to the node's images
+      if (
+        ComfyApp.clipspace.imgs?.[ComfyApp.clipspace.combinedIndex] &&
+        node.imgs &&
+        combinedImgSrc
+      ) {
+        const combinedImg = new Image()
+        combinedImg.src = combinedImgSrc
+        node.imgs.push(combinedImg) // Add the combined canvas to the node's images
       }
 
       // Paste the RGB canvas if paintedindex exists
-      if (ComfyApp.clipspace.imgs?.[ComfyApp.clipspace.paintedIndex] && node.imgs) {
-        const paintedImg = new Image();
-        paintedImg.src = ComfyApp.clipspace.imgs[ComfyApp.clipspace.paintedIndex].src;
-        node.imgs.push(paintedImg); // Add the RGB canvas to the node's images
+      if (
+        ComfyApp.clipspace.imgs?.[ComfyApp.clipspace.paintedIndex] &&
+        node.imgs
+      ) {
+        const paintedImg = new Image()
+        paintedImg.src =
+          ComfyApp.clipspace.imgs[ComfyApp.clipspace.paintedIndex].src
+        node.imgs.push(paintedImg) // Add the RGB canvas to the node's images
       }
-      
-  
+
       if (node.widgets) {
         if (ComfyApp.clipspace.images) {
           const clip_image =
-            ComfyApp.clipspace.images[ComfyApp.clipspace['selectedIndex']];
-          const index = node.widgets.findIndex((obj) => obj.name === 'image');
+            ComfyApp.clipspace.images[ComfyApp.clipspace['selectedIndex']]
+          const index = node.widgets.findIndex((obj) => obj.name === 'image')
           if (index >= 0) {
             if (
               node.widgets[index].type != 'image' &&
@@ -443,9 +454,9 @@ export class ComfyApp {
               node.widgets[index].value =
                 (clip_image.subfolder ? clip_image.subfolder + '/' : '') +
                 clip_image.filename +
-                (clip_image.type ? ` [${clip_image.type}]` : '');
+                (clip_image.type ? ` [${clip_image.type}]` : '')
             } else {
-              node.widgets[index].value = clip_image;
+              node.widgets[index].value = clip_image
             }
           }
         }
@@ -472,11 +483,15 @@ export class ComfyApp {
                 prop.callback?.(value)
               }
             }
-          });
+          })
         }
       }
-  
-      app.graph.setDirtyCanvas(true);
+
+      node.imgs?.forEach((imgEl) => {
+        if (imgEl.src === combinedImgSrc) return
+        imgEl.setAttribute('data-nopreview', 'true')
+      })
+      app.graph.setDirtyCanvas(true)
     }
   }
 


### PR DESCRIPTION
Main repo PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/4361

This PR:
- Ensures the node preview of a loaded image is that of the combined canvas (base image + mask + paint), with no other previewable image. [3e259c9](https://github.com/brucew4yn3rp/ComfyUI_frontend_ImageEditor/pull/2/commits/3e259c9ea60014bf5b3113063f63100674340857)
- Improves layer-switching UX (details below) [fbff95b](https://github.com/brucew4yn3rp/ComfyUI_frontend_ImageEditor/pull/2/commits/fbff95b8eac8d9cbeff8da5be6e570719dfbded4)
- Fixes the regression where square brush shapes became always round (NOTE: when hardness<1, brush shape becomes round, but this is true in main branch as well) [118522f](https://github.com/brucew4yn3rp/ComfyUI_frontend_ImageEditor/pull/2/commits/118522f1c9a2056ed3d758296b37dcb71d469286)
- Adds [ and ] as keyboard shortcuts to decrease/increase brush size [c744eeb](https://github.com/brucew4yn3rp/ComfyUI_frontend_ImageEditor/pull/2/commits/c744eeb774083bedbf69778fd6ac60350521376d)

## Preview image bug and fix explanation

The previewed images are pulled from the `LGraphNode` object's `imgs` (`HTMLImageElement[]`) property, and the way the code works, MaskEditor is initialized expecting the different layers to also be in that `imgs` array, and refactoring that would be difficult and high-risk. As a simple fix, I added a `data-nopreview` data attribute to the HTMLImageElement objects, to be able to supply MaskEditor with the discrete layers while only previewing the combined canvas.

~~Before the main repo PR can be merged, we will also need to automatically select an image layer when opening the MaskEditor.~~ Fixed in 5187121c6160961a76cefa3252c2eb4ad4ec8880

Note: after refreshing the page, the paint layer is no longer editable. I'd suggest not considering this bug as a blocker for the main repo PR, as it could be a deep rabbit hole for a very minor bug.

## Layer UX improvements

This PR improves the layer UX in [fbff95b](https://github.com/brucew4yn3rp/ComfyUI_frontend_ImageEditor/pull/2/commits/fbff95b8eac8d9cbeff8da5be6e570719dfbded4). Here is an explanation copied from the commit of the UX improvements. We should copy this explanation to the parent PR after this child PR, for the benefit of reviewers.

In order to explain the new UX let me first explain what I'll call the different tools, as the names we previously used are now ambiguous.

- "Mask Pen": Previously named "Pen" internally, this is an existing tool lets you paint a mask on the image.
- "Paint Pen": New tool which lets you paint colored pixels on the image.
- "Eraser": Exising tool which lets you erase parts of your mask. As of @brucew4yn3rp's PR, you can also erase parts of your painted pixels, depending on which layer is active.
- "Mask Bucket": Previously named "Paint Bucket" internally, this is an existing tool which lets you take a mask that's just an outline, and fill in the inside of your mask outline with a full masked area. Equivalent functionality for the Paint layer is NOT implemented. **I'd suggest this not being a blocker for the main PR.**
- "Mask Color Fill": Previously named "Color Select" internally, this is an existing tool which can turn pixels into a masked area, based on color similarity in contiguous pixels on the base image. Equivalent functionality for the Paint layer is NOT implemented. **I'd suggest this not being a blocker for the main PR.**

New UX:

- The "Mask" layer is now selected when you open the Mask Editor, instead of no layer selected.
- Selecting the "Mask Pen", "Mask Bucket", or "Mask Color Fill" tool automatically selects the Mask layer.
- Selecting the "Paint Pen" tool automatically selects the Paint layer.
- Selecting the "Mask" layer while the "Paint Pen" tool is selected automatically selects the "Mask Pen" tool.
- Selecting the "Paint" layer while the "Mask Pen", "Mask Bucket", or "Mask Color Fill" tool is selected automatically selects the "Paint Pen" tool.
- Changing the selected layer while the "Eraser" tool is selected has no additional effect, because Eraser supports both layers.
- Switching to the "Eraser" tool has no additional effect, because Eraser supports both layers.

![1751908337](https://github.com/user-attachments/assets/98a92e03-b2de-44df-893c-3042540b3c00)

